### PR TITLE
Обновил docker-compose.prod.yml для запуска STT на DatabaseMart GPU-с…

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,28 @@
+services:
+  stt:
+    image: antonijzelinskij/stt:trial-databasemart
+    container_name: elixir-stt
+    restart: unless-stopped
+    runtime: nvidia
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
+      - NVIDIA_DRIVER_CAPABILITIES=compute,utility
+    ports:
+      - "8001:8080"
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/ping', timeout=5).read()",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "5"


### PR DESCRIPTION
…ервере.

Что изменено:
- заменён локальный image elixir-stt:prod на Docker Hub image antonijzelinskij/stt:trial-databasemart;
- внешний порт изменён на 8001, внутренний порт контейнера остался 8080;
- добавлен runtime: nvidia;
- добавлены NVIDIA_VISIBLE_DEVICES=all и NVIDIA_DRIVER_CAPABILITIES=compute,utility;